### PR TITLE
APIS-3256

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -782,7 +782,11 @@ func Set(data []byte, setValue []byte, keys ...string) (value []byte, err error)
 		} else {
 			startOffset = depthOffset
 		}
-		value = append(data[:startOffset], append(createInsertComponent(keys[depth:], setValue, comma, object), data[depthOffset:]...)...)
+
+		// Similar to Delete, we have to make a copy here if we don't want to mangle the original data.
+		dataCopy := make([]byte, len(data))
+		copy(dataCopy, data)
+		value = append(dataCopy[:startOffset], append(createInsertComponent(keys[depth:], setValue, comma, object), dataCopy[depthOffset:]...)...)
 	} else {
 		// path currently exists
 		startComponent := data[:startOffset]


### PR DESCRIPTION
**Description**: What this PR does

**Benchmark before change**:

goos: darwin
goarch: amd64
pkg: github.com/GannettDigital/jsonparser/benchmark
BenchmarkJsonParserLarge-8                        200000             56301 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-8                      1000000              8922 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-8                1000000             11939 ns/op           12160 B/op          4 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8         1000000              5515 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8         1000000              6080 ns/op             544 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8      1000000              8918 ns/op             496 B/op         11 allocs/op
BenchmarkJsonParserSmall-8                      10000000               838 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8         10000000               652 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8         10000000               848 ns/op             192 B/op          8 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8      10000000               753 ns/op             176 B/op          7 allocs/op
BenchmarkJsonParserSetSmall-8                   10000000              1141 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall-8                    5000000              1812 ns/op             720 B/op          4 allocs/op
PASS
ok      github.com/GannettDigital/jsonparser/benchmark  112.047s

**Benchmark after change**:

goos: darwin
goarch: amd64
pkg: github.com/GannettDigital/jsonparser/benchmark
BenchmarkJsonParserLarge-8                        200000             56097 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserMedium-8                      1000000              8681 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserDeleteMedium-8                1000000             12089 ns/op           12160 B/op          4 allocs/op
BenchmarkJsonParserEachKeyManualMedium-8         1000000              5345 ns/op             112 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructMedium-8         1000000              6110 ns/op             544 B/op         12 allocs/op
BenchmarkJsonParserObjectEachStructMedium-8      1000000              9147 ns/op             496 B/op         11 allocs/op
BenchmarkJsonParserSmall-8                      10000000               822 ns/op               0 B/op          0 allocs/op
BenchmarkJsonParserEachKeyManualSmall-8         10000000               652 ns/op              80 B/op          2 allocs/op
BenchmarkJsonParserEachKeyStructSmall-8         10000000               872 ns/op             192 B/op          8 allocs/op
BenchmarkJsonParserObjectEachStructSmall-8      10000000               765 ns/op             176 B/op          7 allocs/op
BenchmarkJsonParserSetSmall-8                   10000000              1166 ns/op             768 B/op          4 allocs/op
BenchmarkJsonParserDelSmall-8                    3000000              1895 ns/op             720 B/op          4 allocs/op
PASS
ok      github.com/GannettDigital/jsonparser/benchmark  108.747s

For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```